### PR TITLE
Fix hook environment and auto-cd functionality

### DIFF
--- a/cmd/wtp/completion.go
+++ b/cmd/wtp/completion.go
@@ -656,6 +656,9 @@ wtp() {
             local worktree_name=""
             local found_b=0
             
+            # Save original arguments for reuse
+            local orig_args=("$@")
+            
             # Create a copy of arguments for parsing
             set -- "$@"
             shift # skip 'add'
@@ -675,7 +678,7 @@ wtp() {
             
             # If no -b option, find the last non-flag argument
             if [[ $found_b -eq 0 ]]; then
-                set -- "$@"
+                set -- "${orig_args[@]}"
                 shift # skip 'add' again
                 while [[ $# -gt 0 ]]; do
                     if [[ "$1" != -* ]]; then

--- a/internal/hooks/executor.go
+++ b/internal/hooks/executor.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/satococoa/wtp/internal/config"
 )
@@ -123,8 +124,15 @@ func (e *Executor) executeCommandHookWithWriter(w io.Writer, hook *config.Hook, 
 	}
 	cmd.Dir = workDir
 
-	// Set environment variables
-	cmd.Env = os.Environ()
+	// Set environment variables (filter out WTP_SHELL_INTEGRATION)
+	env := os.Environ()
+	filtered := make([]string, 0, len(env))
+	for _, e := range env {
+		if !strings.HasPrefix(e, "WTP_SHELL_INTEGRATION=") {
+			filtered = append(filtered, e)
+		}
+	}
+	cmd.Env = filtered
 	for key, value := range hook.Env {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
 	}


### PR DESCRIPTION
## Summary
- Fix environment variable leakage from shell integration to hooks
- Improve auto-cd functionality after `wtp add` commands
- Rename variables for better code clarity

## Changes

### 1. Environment Variable Filtering in Hooks
- Filter out `WTP_SHELL_INTEGRATION` from hook execution environment
- Prevents shell integration state from affecting hook commands
- Ensures e2e tests run in clean environment when executed through hooks

### 2. Auto-CD Functionality Improvements
- Fix branch name extraction logic for `-b/--branch` options
- Properly handle worktree name detection for auto-cd after `wtp add`
- Support all shell types (bash, zsh, fish) consistently

### 3. Code Clarity Improvements
- Rename `branch_name` variables to `worktree_name` for accuracy
- Update comments to reflect actual functionality

## Test plan
- [x] e2e tests pass when run directly
- [x] Shell integration works correctly with `-b` option
- [x] Hook execution no longer pollutes environment variables
- [x] Auto-cd functionality works for various `wtp add` scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced the reliability of shell integration for the `wtp add` command across bash, zsh, and fish by improving how the target worktree name is determined from command-line arguments.
  * Updated environment handling to prevent certain internal environment variables from being passed to hooks, ensuring cleaner and more predictable execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->