### PR TITLE
docs: clarify copy hook path behavior and improve examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,14 +182,15 @@ defaults:
 
 hooks:
   post_create:
-    # Copy files from repository root to new worktree
+    # Copy gitignored files from main worktree to new worktree
+    # Note: 'from' is relative to main worktree, 'to' is relative to new worktree
     - type: copy
-      from: ".env.example"
+      from: ".env"  # Copy actual .env file (gitignored)
       to: ".env"
 
     - type: copy
-      from: "config/database.yml.example"
-      to: "config/database.yml"
+      from: ".claude"  # Copy AI context file (gitignored)
+      to: ".claude"
 
     # Execute commands in the new worktree
     - type: command
@@ -201,6 +202,36 @@ hooks:
       command: "make db:setup"
       work_dir: "."
 ```
+
+### Copy Hooks: Main Worktree Reference
+
+Copy hooks are designed to help you bootstrap new worktrees using files from your main worktree (even if they are gitignored):
+
+- `from`: path is always resolved relative to the main worktree.
+- `to`: path is resolved relative to the newly created worktree.
+- Supports files and directories, including entries ignored by Git (e.g., `.env`, `.claude`, `.cursor/`).
+
+Examples:
+
+```yaml
+hooks:
+  post_create:
+    # Copy local env and AI context from MAIN worktree into the new worktree
+    - type: copy
+      from: ".env"
+      to: ".env"
+
+    - type: copy
+      from: ".claude"
+      to: ".claude"
+
+    # Directory copy also works
+    - type: copy
+      from: ".cursor/"
+      to: ".cursor/"
+```
+
+This behavior applies regardless of where you run `wtp add` from (main worktree or any other worktree).
 
 ## Shell Integration
 

--- a/cmd/wtp/init.go
+++ b/cmd/wtp/init.go
@@ -58,22 +58,31 @@ defaults:
 # Hooks that run after creating a worktree
 hooks:
   post_create:
-    # Example: Copy environment file
-    - type: copy
-      from: .env.example
-      to: .env
+    # Example: Copy gitignored files from MAIN worktree to new worktree
+    # Note: 'from' is relative to main worktree, 'to' is relative to new worktree
+    # - type: copy
+    #   from: .env        # Copy actual .env file (gitignored)
+    #   to: .env
 
     # Example: Run a command to show all worktrees
     - type: command
       command: wtp list
 
     # More examples (commented out):
-    # - type: command
-    #   command: echo "Created new worktree!"
-    # - type: command
-    #   command: ls -la
+    
+    # Copy AI context files (typically gitignored):
+    # - type: copy
+    #   from: .claude     # Claude AI context
+    #   to: .claude
+    # - type: copy
+    #   from: .cursor/    # Cursor IDE settings
+    #   to: .cursor/
+    
+    # Run setup commands:
     # - type: command
     #   command: npm install
+    # - type: command
+    #   command: echo "Created new worktree!"
 `
 
 	// Write configuration file with comments

--- a/cmd/wtp/init_test.go
+++ b/cmd/wtp/init_test.go
@@ -144,7 +144,7 @@ func TestInitCommand_Success(t *testing.T) {
 
 	// Check for example hooks
 	assert.Contains(t, contentStr, "type: copy")
-	assert.Contains(t, contentStr, "from: .env.example")
+	assert.Contains(t, contentStr, "from: .env")
 	assert.Contains(t, contentStr, "to: .env")
 	assert.Contains(t, contentStr, "type: command")
 	assert.Contains(t, contentStr, "command: wtp")


### PR DESCRIPTION
## Summary
- Clarifies copy hook path behavior based on Issue #11 discussion
- Provides more practical examples using gitignored files
- Updates both README documentation and `wtp init` template

## Background
In Issue #11, a user requested support for special variables like `${MAIN_WORKTREE}` or `@main/` prefix to reference files from the main worktree. However, this functionality already exists by default - `from` paths are always relative to the main worktree.

This PR clarifies the documentation to prevent similar confusion in the future.

## Changes
1. **README.md**:
   - Added dedicated "Copy Hooks: Main Worktree Reference" section
   - Replaced misleading `.env.example` examples with real gitignored files (`.env`, `.claude`)
   - Added clear explanation that `from` is relative to main worktree

2. **wtp init template**:
   - Updated generated config with better examples
   - Added comments explaining path behavior
   - Included practical examples for AI context files (`.claude`, `.cursor/`)

3. **Tests**:
   - Updated test assertions to match new examples

## Test plan
- [x] All tests pass (`go tool task dev`)
- [x] Manual testing of `wtp init` generates correct config
- [x] Documentation is clear and addresses the original confusion

Closes #11

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved documentation to clarify how the `copy` hook works, including support for copying gitignored files and directories.
  * Updated and expanded example snippets for common use cases in both the README and generated configuration files.

* **Tests**
  * Updated tests to align with the new example configuration, ensuring consistency with the revised documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->