### PR TITLE
Remove auto-cd functionality from wtp add command

### DIFF
--- a/cmd/wtp/completion.go
+++ b/cmd/wtp/completion.go
@@ -374,53 +374,6 @@ wtp() {
         else
             WTP_SHELL_INTEGRATION=1 command wtp cd "$2"
         fi
-    elif [[ "$1" == "add" ]]; then
-        # Run the add command and capture only the last line for cd detection
-        local last_line
-        local exit_code
-        
-        # Run command and capture exit code
-        WTP_SHELL_INTEGRATION=1 command wtp "$@"
-        exit_code=$?
-        
-        # If successful, try to cd to the new worktree
-        if [[ $exit_code -eq 0 ]]; then
-            # Extract worktree name from arguments
-            local worktree_name=""
-            local args=("$@")
-            local i
-            
-            # First, check for -b/--branch option
-            for ((i=2; i<=${#args[@]}; i++)); do
-                if [[ "${args[$i]}" == "-b" || "${args[$i]}" == "--branch" ]]; then
-                    if [[ $((i+1)) -le ${#args[@]} ]]; then
-                        worktree_name="${args[$((i+1))]}"
-                        break
-                    fi
-                fi
-            done
-            
-            # If no -b option, use the last non-flag argument
-            if [[ -z "$worktree_name" ]]; then
-                for ((i=${#args[@]}; i>=2; i--)); do
-                    if [[ "${args[$i]}" != -* ]]; then
-                        worktree_name="${args[$i]}"
-                        break
-                    fi
-                done
-            fi
-            
-            # Try to cd to the worktree
-            if [[ -n "$worktree_name" ]]; then
-                local target_dir
-                target_dir=$(WTP_SHELL_INTEGRATION=1 command wtp cd "$worktree_name" 2>/dev/null)
-                if [[ $? -eq 0 && -n "$target_dir" && -d "$target_dir" ]]; then
-                    cd "$target_dir"
-                fi
-            fi
-        fi
-        
-        return $exit_code
     else
         command wtp "$@"
     fi
@@ -641,64 +594,6 @@ wtp() {
         else
             WTP_SHELL_INTEGRATION=1 command wtp cd "$2"
         fi
-    elif [[ "$1" == "add" ]]; then
-        # Run the add command and capture only the last line for cd detection
-        local last_line
-        local exit_code
-        
-        # Run command and capture exit code
-        WTP_SHELL_INTEGRATION=1 command wtp "$@"
-        exit_code=$?
-        
-        # If successful, try to cd to the new worktree
-        if [[ $exit_code -eq 0 ]]; then
-            # Extract worktree name from arguments
-            local worktree_name=""
-            local found_b=0
-            
-            # Save original arguments for reuse
-            local orig_args=("$@")
-            
-            # Create a copy of arguments for parsing
-            set -- "$@"
-            shift # skip 'add'
-            
-            # First, check for -b/--branch option
-            while [[ $# -gt 0 ]]; do
-                if [[ "$1" == "-b" || "$1" == "--branch" ]]; then
-                    shift
-                    if [[ $# -gt 0 ]]; then
-                        worktree_name="$1"
-                        found_b=1
-                        break
-                    fi
-                fi
-                shift
-            done
-            
-            # If no -b option, find the last non-flag argument
-            if [[ $found_b -eq 0 ]]; then
-                set -- "${orig_args[@]}"
-                shift # skip 'add' again
-                while [[ $# -gt 0 ]]; do
-                    if [[ "$1" != -* ]]; then
-                        worktree_name="$1"
-                    fi
-                    shift
-                done
-            fi
-            
-            # Try to cd to the worktree
-            if [[ -n "$worktree_name" ]]; then
-                local target_dir
-                target_dir=$(WTP_SHELL_INTEGRATION=1 command wtp cd "$worktree_name" 2>/dev/null)
-                if [[ $? -eq 0 && -n "$target_dir" && -d "$target_dir" ]]; then
-                    cd "$target_dir"
-                fi
-            fi
-        fi
-        
-        return $exit_code
     else
         command wtp "$@"
     fi
@@ -735,48 +630,6 @@ function wtp
         else
             env WTP_SHELL_INTEGRATION=1 command wtp cd $argv[2]
         end
-    else if test "$argv[1]" = "add"
-        # Run the add command and capture exit code
-        env WTP_SHELL_INTEGRATION=1 command wtp $argv
-        set -l exit_code $status
-        
-        # If successful, try to cd to the new worktree
-        if test $exit_code -eq 0
-            # Extract worktree name from arguments
-            set -l worktree_name ""
-            set -l found_b 0
-            
-            # First, check for -b/--branch option
-            for i in (seq 2 (count $argv))
-                if test "$argv[$i]" = "-b" -o "$argv[$i]" = "--branch"
-                    if test (math $i + 1) -le (count $argv)
-                        set worktree_name $argv[(math $i + 1)]
-                        set found_b 1
-                        break
-                    end
-                end
-            end
-            
-            # If no -b option, find the last non-flag argument
-            if test $found_b -eq 0
-                for i in (seq (count $argv) -1 2)
-                    if not string match -q -- "-*" $argv[$i]
-                        set worktree_name $argv[$i]
-                        break
-                    end
-                end
-            end
-            
-            # Try to cd to the worktree
-            if test -n "$worktree_name"
-                set -l target_dir (env WTP_SHELL_INTEGRATION=1 command wtp cd $worktree_name 2>/dev/null)
-                if test $status -eq 0 -a -n "$target_dir" -a -d "$target_dir"
-                    cd $target_dir
-                end
-            end
-        end
-        
-        return $exit_code
     else
         command wtp $argv
     end


### PR DESCRIPTION
## Summary
- Removes the automatic directory change behavior from `wtp add` command
- Simplifies the codebase by removing complex shell wrapper logic
- Makes behavior more predictable and explicit

## Breaking Change
**Before:** `wtp add feature/xyz` would automatically cd to the new worktree  
**After:** Users need to explicitly run `wtp add feature/xyz && wtp cd feature/xyz`

## Changes
- Removed auto-cd logic from bash completion script
- Removed auto-cd logic from zsh completion script  
- Removed auto-cd logic from fish completion script
- No documentation updates needed (feature was not documented)
- All tests pass

## Migration Guide
Users who relied on the auto-cd behavior will need to update their workflow:

```bash
# Before (v1.1.x)
wtp add feature/new-feature  # Automatically cd's to new worktree

# After (v1.2.0)
wtp add feature/new-feature && wtp cd feature/new-feature
```

## Test Plan
- [x] Run `go tool task dev` - all tests pass
- [x] Manually test `wtp add` command - creates worktree without changing directory
- [x] Shell completion still works for all shells

This is the first step in the migration plan outlined in the Untitled.md document, preparing for the future `wtp init-shell` command architecture.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified shell integration for the add command across Bash, Zsh, and Fish.
  - The shell no longer auto-navigates to the newly created worktree after running add.
  - Commands now execute without post-add directory changes; users should cd manually if desired.
  - Other completion features and cd helpers remain unchanged and continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->