### PR TITLE
fix: stabilize stdout redirection in completion tests

### DIFF
--- a/cmd/wtp/add_test.go
+++ b/cmd/wtp/add_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -940,10 +939,8 @@ func TestCompleteBranches(t *testing.T) {
 
 		// Should not panic even without proper git setup
 		assert.NotPanics(t, func() {
-			// Capture stdout to avoid noise in tests
-			oldStdout := os.Stdout
-			os.Stdout = os.NewFile(0, os.DevNull)
-			defer func() { os.Stdout = oldStdout }()
+			restore := silenceStdout(t)
+			defer restore()
 
 			completeBranches(context.Background(), cmd)
 		})

--- a/cmd/wtp/cd_test.go
+++ b/cmd/wtp/cd_test.go
@@ -231,10 +231,8 @@ func TestCompleteWorktreesForCd(t *testing.T) {
 
 		// Should not panic even without proper git setup
 		assert.NotPanics(t, func() {
-			// Capture stdout to avoid noise in tests
-			oldStdout := os.Stdout
-			os.Stdout = os.NewFile(0, os.DevNull)
-			defer func() { os.Stdout = oldStdout }()
+			restore := silenceStdout(t)
+			defer restore()
 
 			completeWorktreesForCd(context.Background(), cmd)
 		})

--- a/cmd/wtp/remove_test.go
+++ b/cmd/wtp/remove_test.go
@@ -841,10 +841,8 @@ func TestCompleteWorktrees(t *testing.T) {
 
 		// Should not panic even without proper git setup
 		assert.NotPanics(t, func() {
-			// Capture stdout to avoid noise in tests
-			oldStdout := os.Stdout
-			os.Stdout = os.NewFile(0, os.DevNull)
-			defer func() { os.Stdout = oldStdout }()
+			restore := silenceStdout(t)
+			defer restore()
 
 			completeWorktrees(context.Background(), cmd)
 		})

--- a/cmd/wtp/stdout_test.go
+++ b/cmd/wtp/stdout_test.go
@@ -13,7 +13,7 @@ func silenceStdout(t *testing.T) func() {
 
 	old := os.Stdout
 
-	f, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	f, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0644)
 	if err != nil {
 		t.Fatalf("failed to open %s: %v", os.DevNull, err)
 	}

--- a/cmd/wtp/stdout_test.go
+++ b/cmd/wtp/stdout_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+// silenceStdout redirects stdout to os.DevNull for the duration of the returned
+// restore function to avoid polluting test output while preserving a writable
+// file descriptor for go test tooling (e.g. coverage generation).
+func silenceStdout(t *testing.T) func() {
+	t.Helper()
+
+	old := os.Stdout
+
+	f, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("failed to open %s: %v", os.DevNull, err)
+	}
+
+	os.Stdout = f
+
+	return func() {
+		os.Stdout = old
+		if err := f.Close(); err != nil {
+			t.Fatalf("failed to close %s: %v", os.DevNull, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a helper that redirects stdout to /dev/null without clobbering fds
- reuse the helper in completion-related tests to avoid bad file descriptors on macOS runners

## Testing
- go tool task test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Consolidated stdout suppression into a reusable test helper to reduce noisy test output.
  - Updated related tests to use the helper for consistent, cleaner execution and easier maintenance.
  - Improved test readability by standardizing output silencing across the suite.
  - No changes to user-facing behavior or public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->