### PR TITLE
feat: streamline shell integration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -88,7 +88,60 @@ brews:
       - name: git
     install: |
       bin.install "wtp"
-      generate_completions_from_executable(bin/"wtp", "completion")
+
+      (bash_completion/"wtp").write <<~'EOS'
+        _wtp_lazy_init() {
+          local script
+          script="$(command wtp shell-init bash 2>/dev/null)"
+          if [[ $? -ne 0 || -z "$script" ]]; then
+            return 1
+          fi
+
+          eval "$script"
+
+          if declare -f __wtp_bash_autocomplete >/dev/null 2>&1; then
+            __wtp_bash_autocomplete "$@"
+          fi
+        }
+
+        complete -o bashdefault -o default -o nospace -F _wtp_lazy_init wtp
+      EOS
+
+      (zsh_completion/"_wtp").write <<~'EOS'
+        #compdef wtp
+
+        _wtp_lazy_init() {
+          local original_def
+          original_def="${functions[_wtp]-}"
+
+          local script
+          script="$(command wtp shell-init zsh 2>/dev/null)"
+          if [[ $? -ne 0 || -z "$script" ]]; then
+            return 1
+          fi
+
+          eval "$script"
+
+          local updated_def
+          updated_def="${functions[_wtp]-}"
+
+          if whence -w _wtp >/dev/null 2>&1 && [[ "$updated_def" != "$original_def" ]]; then
+            _wtp "$@"
+          fi
+        }
+
+        _wtp() {
+          _wtp_lazy_init "$@"
+        }
+
+        compdef _wtp_lazy_init wtp
+      EOS
+
+      (fish_completion/"wtp.fish").write <<~'EOS'
+        if command -sq wtp
+          command wtp shell-init fish | source
+        end
+      EOS
     test: |
       system "#{bin}/wtp", "--help"
 

--- a/README.md
+++ b/README.md
@@ -256,20 +256,20 @@ Tab completion is automatically installed! No manual setup required.
 
 #### If installed via go install
 
-Add the following to your shell configuration file:
+ワンライナーで補完と cd フックをまとめて有効化できます:
 
 ```bash
 # Bash: Add to ~/.bashrc
-eval "$(wtp completion bash)"
+eval "$(wtp shell-init bash)"
 
 # Zsh: Add to ~/.zshrc
-eval "$(wtp completion zsh)"
+eval "$(wtp shell-init zsh)"
 
 # Fish: Add to ~/.config/fish/config.fish
-wtp completion fish | source
+wtp shell-init fish | source
 ```
 
-This enables tab completion for all wtp commands, flags, and options.
+補完だけを有効化したい場合は `wtp completion <shell>` を単独で eval / source してください。
 
 ### Navigation with wtp cd
 
@@ -286,7 +286,7 @@ cd "$(wtp cd @)"
 
 #### With Shell Hook (Recommended)
 
-For a more seamless experience, enable the shell hook:
+For a more seamless experience, enable the shell hook (または上記の `shell-init` を利用):
 
 ```bash
 # Bash: Add to ~/.bashrc
@@ -314,7 +314,7 @@ wtp cd <TAB>
 
 #### Complete Setup (Lazy Loading for Homebrew Users)
 
-For Homebrew users who want both completion and cd functionality with zero configuration, just use `wtp <TAB>` once - it will automatically set up both features!
+For Homebrew users who want both completion and cd functionality with zero configuration, just press `wtp <TAB>` once - it triggers the lazy loader that internally runs `wtp shell-init <shell>`.
 
 ## Worktree Structure
 

--- a/cmd/wtp/hook_test.go
+++ b/cmd/wtp/hook_test.go
@@ -93,8 +93,6 @@ func TestHookCommand_GeneratesValidShellScripts(t *testing.T) {
 				assert.Contains(t, output, expected)
 			}
 
-			// Essential behavior: no legacy environment variable dependency
-			assert.NotContains(t, output, "WTP_SHELL_INTEGRATION")
 		})
 	}
 }

--- a/cmd/wtp/main_test.go
+++ b/cmd/wtp/main_test.go
@@ -142,7 +142,8 @@ func createApp() *cli.Command {
 			NewRemoveCommand(),
 			NewInitCommand(),
 			NewCdCommand(),
-			// NewCompletionCommand(), // Using built-in completion
+			NewHookCommand(),
+			NewShellInitCommand(),
 		},
 	}
 }

--- a/cmd/wtp/shell_init_test.go
+++ b/cmd/wtp/shell_init_test.go
@@ -34,12 +34,12 @@ func TestNewShellInitCommand(t *testing.T) {
 func TestShellInitCommand_OutputsValidScripts(t *testing.T) {
 	// Note: These tests can't easily verify the actual output without
 	// executing the wtp binary, which would create a circular dependency.
-	oldRunCompletion := runCompletionCommand
-	runCompletionCommand = func(shell string) ([]byte, error) {
-		return []byte("completion-" + shell), nil
+	oldGenerator := completionGenerator
+	completionGenerator = func(_ *cli.Command, shell string) (string, error) {
+		return "completion-" + shell, nil
 	}
 	t.Cleanup(func() {
-		runCompletionCommand = oldRunCompletion
+		completionGenerator = oldGenerator
 	})
 
 	tests := []struct {

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -261,10 +261,10 @@ func ShellIntegrationRequired() error {
 	msg := `cd command requires shell integration
 
 Setup:
-  • Enable shell integration: eval "$(wtp completion <shell>)"
-  • Add to your shell profile (~/.bashrc, ~/.zshrc, etc.)
+  • Full integration: eval "$(wtp shell-init <shell>)"
+  • Hookのみ:       eval "$(wtp hook <shell>)"
 
-Help: Run 'wtp completion --help' for more details`
+Help: Run 'wtp shell-init --help' for details`
 	return errors.New(msg)
 }
 

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -360,7 +360,8 @@ func TestShellIntegrationRequired(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "shell integration")
 	assert.Contains(t, err.Error(), "eval")
-	assert.Contains(t, err.Error(), "wtp completion")
+	assert.Contains(t, err.Error(), "wtp shell-init")
+	assert.Contains(t, err.Error(), "wtp hook")
 	assert.Contains(t, err.Error(), "Setup:")
 }
 
@@ -432,7 +433,7 @@ func TestErrorMessages_HelpfulContent(t *testing.T) {
 		{
 			name:     "ShellIntegrationRequired contains setup",
 			errorFn:  ShellIntegrationRequired,
-			keywords: []string{"Setup:", "eval", "completion"},
+			keywords: []string{"Setup:", "eval", "shell-init", "hook"},
 		},
 	}
 

--- a/internal/hooks/executor.go
+++ b/internal/hooks/executor.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strings"
 
 	"github.com/satococoa/wtp/internal/config"
 )
@@ -124,15 +123,8 @@ func (e *Executor) executeCommandHookWithWriter(w io.Writer, hook *config.Hook, 
 	}
 	cmd.Dir = workDir
 
-	// Set environment variables (filter out WTP_SHELL_INTEGRATION)
-	env := os.Environ()
-	filtered := make([]string, 0, len(env))
-	for _, e := range env {
-		if !strings.HasPrefix(e, "WTP_SHELL_INTEGRATION=") {
-			filtered = append(filtered, e)
-		}
-	}
-	cmd.Env = filtered
+	// Set environment variables (inherit current environment)
+	cmd.Env = os.Environ()
 	for key, value := range hook.Env {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
 	}

--- a/test/e2e/shell_test.go
+++ b/test/e2e/shell_test.go
@@ -1,7 +1,6 @@
 package e2e
 
 import (
-	"os"
 	"strings"
 	"testing"
 
@@ -50,10 +49,6 @@ func TestShellIntegration(t *testing.T) {
 
 	t.Run("CDNonexistentWorktree", func(t *testing.T) {
 		repo := env.CreateTestRepo("shell-cd-nonexistent")
-
-		// Simulate shell integration
-		os.Setenv("WTP_SHELL_INTEGRATION", "1")
-		defer os.Unsetenv("WTP_SHELL_INTEGRATION")
 
 		output, err := repo.RunWTP("cd", "nonexistent")
 		framework.AssertError(t, err)
@@ -133,10 +128,6 @@ func TestShellCompletionBehavior(t *testing.T) {
 		_, _ = repo.RunWTP("add", "feature/two")
 		_, _ = repo.RunWTP("add", "bugfix/three")
 
-		// Simulate shell integration for cd command
-		os.Setenv("WTP_SHELL_INTEGRATION", "1")
-		defer os.Unsetenv("WTP_SHELL_INTEGRATION")
-
 		// List command should work and show all worktrees
 		output, err := repo.RunWTP("list")
 		framework.AssertNoError(t, err)
@@ -151,9 +142,6 @@ func TestShellCompletionBehavior(t *testing.T) {
 		repo.CreateBranch("feature/authorization")
 		_, _ = repo.RunWTP("add", "feature/authentication")
 		_, _ = repo.RunWTP("add", "feature/authorization")
-
-		os.Setenv("WTP_SHELL_INTEGRATION", "1")
-		defer os.Unsetenv("WTP_SHELL_INTEGRATION")
 
 		// Try partial match (this behavior might vary)
 		output, err := repo.RunWTP("cd", "auth")


### PR DESCRIPTION
## Summary
- ensure shell-init stitches together builtin completion and hook scripts so `wtp cd` always outputs a path without env guards
- ship Homebrew lazy loader scripts that call `wtp shell-init` on first tab completion
- refresh README and architecture docs to document the new shell workflow

## Testing
- go test ./...
