### PR TITLE
feat: add lazy shell-init bootstrapper

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -88,7 +88,82 @@ brews:
       - name: git
     install: |
       bin.install "wtp"
-      generate_completions_from_executable(bin/"wtp", "completion")
+
+      (bash_completion/"wtp").write <<~'EOS'
+        # wtp lazy shell-init for bash (installed via Homebrew)
+        _wtp_lazy_init() {
+          if [[ -z "${WTP_SHELL_INIT_DONE:-}" ]]; then
+            local __wtp_init __wtp_status
+            __wtp_init="$(command wtp shell-init bash 2>/dev/null)"
+            __wtp_status=$?
+            if [[ $__wtp_status -ne 0 || -z "$__wtp_init" ]]; then
+              __wtp_init="$(command wtp completion bash 2>/dev/null)"
+              __wtp_status=$?
+            fi
+            if [[ $__wtp_status -ne 0 || -z "$__wtp_init" ]]; then
+              return 124
+            fi
+
+            eval "$__wtp_init"
+            export WTP_SHELL_INIT_DONE=1
+          fi
+
+          if declare -F __wtp_bash_autocomplete >/dev/null 2>&1; then
+            __wtp_bash_autocomplete "$@"
+          fi
+        }
+
+        complete -o bashdefault -o default -o nospace -F _wtp_lazy_init wtp
+      EOS
+
+      (zsh_completion/"_wtp").write <<~'EOS'
+        #compdef wtp
+
+        _wtp_lazy_init() {
+          if [[ -z ${WTP_SHELL_INIT_DONE-} ]]; then
+            local __wtp_init __wtp_status
+            __wtp_init="$(command wtp shell-init zsh 2>/dev/null)"
+            __wtp_status=$?
+            if [[ $__wtp_status -ne 0 || -z "$__wtp_init" ]]; then
+              __wtp_init="$(command wtp completion zsh 2>/dev/null)"
+              __wtp_status=$?
+            fi
+            if [[ $__wtp_status -ne 0 || -z "$__wtp_init" ]]; then
+              return 1
+            fi
+
+            eval "$__wtp_init"
+            export WTP_SHELL_INIT_DONE=1
+          fi
+
+          if typeset -f _wtp >/dev/null 2>&1; then
+            _wtp "$@"
+          fi
+        }
+
+        compdef _wtp_lazy_init wtp
+      EOS
+
+      (fish_completion/"wtp.fish").write <<~'EOS'
+        function __wtp_lazy_setup --on-event fish_prompt --description 'Lazy shell-init for wtp (Homebrew)'
+            functions -e __wtp_lazy_setup
+
+            if not set -q WTP_SHELL_INIT_DONE
+                set -l __wtp_init (command wtp shell-init fish ^/dev/null)
+                set -l __wtp_status $status
+                if test $__wtp_status -ne 0 -o -z "$__wtp_init"
+                    set -l __wtp_init (command wtp completion fish ^/dev/null)
+                    set -l __wtp_status $status
+                end
+                if test $__wtp_status -ne 0 -o -z "$__wtp_init"
+                    return
+                end
+
+                eval $__wtp_init
+                set -gx WTP_SHELL_INIT_DONE 1
+            end
+        end
+      EOS
     test: |
       system "#{bin}/wtp", "--help"
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -149,17 +149,16 @@ brews:
             functions -e __wtp_lazy_setup
 
             if not set -q WTP_SHELL_INIT_DONE
-                set -l __wtp_init (command wtp shell-init fish ^/dev/null)
+                command wtp shell-init fish ^/dev/null | source
                 set -l __wtp_status $status
-                if test $__wtp_status -ne 0 -o -z "$__wtp_init"
-                    set -l __wtp_init (command wtp completion fish ^/dev/null)
-                    set -l __wtp_status $status
+                if test $__wtp_status -ne 0
+                    command wtp completion fish ^/dev/null | source
+                    set __wtp_status $status
                 end
-                if test $__wtp_status -ne 0 -o -z "$__wtp_init"
+                if test $__wtp_status -ne 0
                     return
                 end
 
-                eval $__wtp_init
                 set -gx WTP_SHELL_INIT_DONE 1
             end
         end

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -110,6 +110,8 @@ brews:
 
           if declare -F __wtp_bash_autocomplete >/dev/null 2>&1; then
             __wtp_bash_autocomplete "$@"
+          elif declare -F _wtp >/dev/null 2>&1; then
+            _wtp "$@"
           fi
         }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,24 +279,8 @@ Based on doc3.md, we implemented a clean separation between completion and shell
 
 | Installation Method | Tab Completion | cd Functionality |
 |-------------------|----------------|------------------|
-| **Homebrew** | Automatic | `eval "$(wtp hook <shell>)"` |
-| **go install** | `eval "$(wtp completion <shell>)"` | `eval "$(wtp hook <shell>)"` |
-
-#### Lazy Loading (Future Homebrew Enhancement)
-
-```ruby
-# Proposed Homebrew formula enhancement
-(bash_completion/"wtp").write <<~EOS
-  _wtp_lazy_init() {
-    eval "$(wtp shell-init bash)"
-    complete -r wtp
-    _wtp "$@"
-  }
-  complete -F _wtp_lazy_init wtp
-EOS
-```
-
-This enables zero-configuration setup where first `wtp <TAB>` automatically configures everything.
+| **Homebrew** | Automatic via lazy `wtp shell-init <shell>` | Automatic via lazy `wtp shell-init <shell>` |
+| **go install** | Add `eval "$(wtp shell-init <shell>)"` to rc | Same `wtp shell-init <shell>` |
 
 #### Benefits Achieved
 

--- a/README.md
+++ b/README.md
@@ -252,24 +252,26 @@ or any other worktree).
 
 #### If installed via Homebrew
 
-Tab completion is automatically installed! No manual setup required.
+No manual setup required. Homebrew installs a tiny bootstrapper that runs `wtp shell-init <shell>` the first time you press `TAB` after typing `wtp`. That lazy call gives you both tab completion and the `wtp cd` integration for the rest of the session—no rc edits needed.
+
+Need to refresh inside an existing shell? Just run `wtp shell-init <shell>` yourself.
 
 #### If installed via go install
 
-Add the following to your shell configuration file:
+Add a single line to your shell configuration file to enable both completion and shell integration:
 
 ```bash
-# Bash: Add to ~/.bashrc
-eval "$(wtp completion bash)"
+# Bash: Add to ~/.bashrc or ~/.bash_profile
+eval "$(wtp shell-init bash)"
 
 # Zsh: Add to ~/.zshrc
-eval "$(wtp completion zsh)"
+eval "$(wtp shell-init zsh)"
 
 # Fish: Add to ~/.config/fish/config.fish
-wtp completion fish | source
+wtp shell-init fish | source
 ```
 
-This enables tab completion for all wtp commands, flags, and options.
+After reloading your shell you get the same experience as Homebrew users.
 
 ### Navigation with wtp cd
 
@@ -286,18 +288,8 @@ cd "$(wtp cd @)"
 
 #### With Shell Hook (Recommended)
 
-For a more seamless experience, enable the shell hook:
+For a more seamless experience, enable the shell hook. `wtp shell-init <shell>` already bundles it, so Homebrew users get the hook automatically and go install users get it from the one-liner above. If you only want the hook without completions, you can still run `wtp hook <shell>` manually.
 
-```bash
-# Bash: Add to ~/.bashrc
-eval "$(wtp hook bash)"
-
-# Zsh: Add to ~/.zshrc
-eval "$(wtp hook zsh)"
-
-# Fish: Add to ~/.config/fish/config.fish
-wtp hook fish | source
-```
 
 Then use the simplified syntax:
 
@@ -314,7 +306,7 @@ wtp cd <TAB>
 
 #### Complete Setup (Lazy Loading for Homebrew Users)
 
-For Homebrew users who want both completion and cd functionality with zero configuration, just use `wtp <TAB>` once - it will automatically set up both features!
+Homebrew ships a lightweight bootstrapper. Press `TAB` after typing `wtp` and it evaluates `wtp shell-init <shell>` once for your session—tab completion and `wtp cd` just work.
 
 ## Worktree Structure
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -178,7 +178,7 @@ cd /path/to/worktrees/feature/auth
 
 - **Environment Variable Check**: `WTP_SHELL_INTEGRATION=1` prevents accidental direct usage
 - **Shell Function Wrapper**: Required because child processes can't change parent's directory
-- **Unified Setup Command**: `wtp completion <shell>` generates both completion and cd functionality
+- **Unified Setup Command**: `wtp shell-init <shell>` generates both completion and cd functionality
 - **Cross-Shell Support**: Bash, Zsh, and Fish implementations
 
 ## Go 1.24 Tool Directive

--- a/docs/development-history.md
+++ b/docs/development-history.md
@@ -37,7 +37,7 @@ This document records the major changes and decisions made during the developmen
 3. **Key Design Decisions**:
    - **Environment Variable Check**: `WTP_SHELL_INTEGRATION=1` prevents accidental direct usage
    - **Shell Function Wrapper**: Required because child processes can't change parent's directory
-   - **Unified Setup Command**: `wtp completion <shell>` generates both completion and cd functionality
+   - **Unified Setup Command**: `wtp shell-init <shell>` combines completion and cd functionality
    - **Cross-Shell Support**: Bash, Zsh, and Fish implementations
 
 **Files Added/Modified**:

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -261,10 +261,10 @@ func ShellIntegrationRequired() error {
 	msg := `cd command requires shell integration
 
 Setup:
-  • Enable shell integration: eval "$(wtp completion <shell>)"
-  • Add to your shell profile (~/.bashrc, ~/.zshrc, etc.)
+  • Homebrew users: press TAB after typing 'wtp' once (automatic)
+  • Other installs: eval "$(wtp shell-init <shell>)" in your shell profile (~/.bashrc, ~/.zshrc, etc.)
 
-Help: Run 'wtp completion --help' for more details`
+Help: Run 'wtp shell-init --help' for more details`
 	return errors.New(msg)
 }
 

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -360,7 +360,7 @@ func TestShellIntegrationRequired(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "shell integration")
 	assert.Contains(t, err.Error(), "eval")
-	assert.Contains(t, err.Error(), "wtp completion")
+	assert.Contains(t, err.Error(), "wtp shell-init")
 	assert.Contains(t, err.Error(), "Setup:")
 }
 
@@ -432,7 +432,7 @@ func TestErrorMessages_HelpfulContent(t *testing.T) {
 		{
 			name:     "ShellIntegrationRequired contains setup",
 			errorFn:  ShellIntegrationRequired,
-			keywords: []string{"Setup:", "eval", "completion"},
+			keywords: []string{"Setup:", "Homebrew", "shell-init"},
 		},
 	}
 


### PR DESCRIPTION
## Summary
- add lazy shell-init bootstrapper to Homebrew completions for bash, zsh, fish
- document shell-init workflow for Homebrew and go install users, update guidance
- refresh shell integration error messaging and tests to match new setup

## Testing
- go test ./...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified shell initialization via wtp shell-init for bash, zsh, and fish; lazy init enabled (Homebrew auto-runs on first TAB; others can eval the shell-init snippet).

* **Documentation**
  * Updated installation, shell-integration, and completion/CD setup instructions and examples to use wtp shell-init; messaging consolidated across install paths.

* **Tests**
  * Updated tests and expected help/error text to reference shell-init.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->