### PR TITLE
fix: resolve shell hook interference with tab completion

### DIFF
--- a/cmd/wtp/cd.go
+++ b/cmd/wtp/cd.go
@@ -362,8 +362,12 @@ func completeWorktreesForCd(_ context.Context, _ *cli.Command) {
 	}
 
 	// Output each line using fmt.Println for urfave/cli compatibility
+	// Strip the asterisk marker used to indicate current worktree
 	scanner := bufio.NewScanner(&buf)
 	for scanner.Scan() {
-		fmt.Println(scanner.Text())
+		line := scanner.Text()
+		// Remove trailing asterisk that marks current worktree
+		line = strings.TrimSuffix(line, "*")
+		fmt.Println(line)
 	}
 }

--- a/cmd/wtp/hook.go
+++ b/cmd/wtp/hook.go
@@ -73,6 +73,14 @@ func hookFish(_ context.Context, cmd *cli.Command) error {
 func printBashHook(w io.Writer) {
 	fmt.Fprintln(w, `# wtp cd command hook for bash
 wtp() {
+    # Pass through completion requests directly
+    for arg in "$@"; do
+        if [[ "$arg" == "--generate-shell-completion" ]]; then
+            command wtp "$@"
+            return $?
+        fi
+    done
+
     if [[ "$1" == "cd" ]]; then
         if [[ -z "$2" ]]; then
             echo "Usage: wtp cd <worktree>" >&2
@@ -94,6 +102,14 @@ wtp() {
 func printZshHook(w io.Writer) {
 	fmt.Fprintln(w, `# wtp cd command hook for zsh
 wtp() {
+    # Pass through completion requests directly
+    for arg in "$@"; do
+        if [[ "$arg" == "--generate-shell-completion" ]]; then
+            command wtp "$@"
+            return $?
+        fi
+    done
+
     if [[ "$1" == "cd" ]]; then
         if [[ -z "$2" ]]; then
             echo "Usage: wtp cd <worktree>" >&2
@@ -115,6 +131,14 @@ wtp() {
 func printFishHook(w io.Writer) {
 	fmt.Fprintln(w, `# wtp cd command hook for fish
 function wtp
+    # Pass through completion requests directly
+    for arg in $argv
+        if test "$arg" = "--generate-shell-completion"
+            command wtp $argv
+            return $status
+        end
+    end
+
     if test "$argv[1]" = "cd"
         if test -z "$argv[2]"
             echo "Usage: wtp cd <worktree>" >&2


### PR DESCRIPTION
## Summary

Fixes tab completion for `wtp cd <tab>` by resolving two issues:
1. Shell hook function was intercepting completion system calls
2. Asterisk markers in completion output caused shell glob issues

## Problem

When using `wtp completion zsh` with `wtp hook zsh`, tab completion failed because:
- The `wtp()` shell function intercepted `--generate-shell-completion` flag
- Instead of passing through to the binary, the hook tried to execute cd logic
- The completion output included `*` markers (e.g., `@*`) which caused shell expansion errors

## Solution

### Hook functions (bash, zsh, fish)
- Added early detection of `--generate-shell-completion` flag
- Pass through directly to `command wtp` when detected
- Prevents hook logic from interfering with completion system

### Completion output (cd.go)
- Strip trailing `*` marker from worktree names
- Marker is useful for `list` command but breaks completion
- Clean output allows proper shell completion matching

## Test Plan

Manual testing completed:
- [x] Tab completion works: `wtp cd <tab>` shows all worktrees
- [x] cd functionality still works: `wtp cd <worktree>` navigates correctly
- [x] Works across bash, zsh, and fish shells
- [x] Unit tests pass for cmd and internal packages

## Files Changed

- `cmd/wtp/cd.go`: Strip asterisk from completion output
- `cmd/wtp/hook.go`: Pass through completion requests in all hooks