### PR TITLE
Add aliases for list and remove commands

### DIFF
--- a/cmd/wtp/list.go
+++ b/cmd/wtp/list.go
@@ -50,6 +50,7 @@ var (
 func NewListCommand() *cli.Command {
 	return &cli.Command{
 		Name:        "list",
+		Aliases:     []string{"ls"},
 		Usage:       "List all worktrees",
 		Description: "Shows all worktrees with their paths, branches, and HEAD commits.",
 		Action:      listCommand,

--- a/cmd/wtp/list_test.go
+++ b/cmd/wtp/list_test.go
@@ -21,6 +21,7 @@ func TestNewListCommand(t *testing.T) {
 
 	assert.NotNil(t, cmd)
 	assert.Equal(t, "list", cmd.Name)
+	assert.Contains(t, cmd.Aliases, "ls")
 	assert.Equal(t, "List all worktrees", cmd.Usage)
 	assert.NotEmpty(t, cmd.Description)
 	assert.NotNil(t, cmd.Action)

--- a/cmd/wtp/remove.go
+++ b/cmd/wtp/remove.go
@@ -68,6 +68,7 @@ func isWorktreeManaged(worktreePath string, cfg *config.Config, mainRepoPath str
 func NewRemoveCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "remove",
+		Aliases:   []string{"rm"},
 		Usage:     "Remove a worktree",
 		UsageText: "wtp remove <worktree-name>",
 		Description: "Removes the worktree with the specified directory name.\n\n" +

--- a/cmd/wtp/remove_test.go
+++ b/cmd/wtp/remove_test.go
@@ -19,6 +19,7 @@ func TestNewRemoveCommand(t *testing.T) {
 	cmd := NewRemoveCommand()
 	assert.NotNil(t, cmd)
 	assert.Equal(t, "remove", cmd.Name)
+	assert.Contains(t, cmd.Aliases, "rm")
 	assert.Equal(t, "Remove a worktree", cmd.Usage)
 	assert.NotEmpty(t, cmd.Description)
 	assert.NotNil(t, cmd.Action)


### PR DESCRIPTION
## Summary
- add an `ls` alias for the `wtp list` command to mirror the git shorthand
- add an `rm` alias for the `wtp remove` command and assert both aliases in unit tests

## Testing
- `go test ./...` *(fails: unable to download modules due to proxy access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68f3903f459483278ff884300eaa9bcf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI aliases: "ls" for the list command and "rm" for the remove command, enabling shorter command invocations.

* **Tests**
  * Added verification that aliases are properly registered for list and remove commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->