### PR TITLE
feat: add flag completion to list command

### DIFF
--- a/cmd/wtp/list.go
+++ b/cmd/wtp/list.go
@@ -49,10 +49,11 @@ var (
 // NewListCommand creates the list command definition
 func NewListCommand() *cli.Command {
 	return &cli.Command{
-		Name:        "list",
-		Aliases:     []string{"ls"},
-		Usage:       "List all worktrees",
-		Description: "Shows all worktrees with their paths, branches, and HEAD commits.",
+		Name:          "list",
+		Aliases:       []string{"ls"},
+		Usage:         "List all worktrees",
+		Description:   "Shows all worktrees with their paths, branches, and HEAD commits.",
+		ShellComplete: completeList,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:    "quiet",
@@ -133,6 +134,12 @@ func listCommandWithCommandExecutor(
 		displayWorktreesRelative(w, worktrees, cwd, cfg, mainRepoPath)
 	}
 	return nil
+}
+
+// completeList provides shell completion for the list command (flags only)
+func completeList(_ context.Context, cmd *cli.Command) {
+	current, previous := completionArgsFromCommand(cmd)
+	maybeCompleteFlagSuggestions(cmd, current, previous)
 }
 
 func parseWorktreesFromOutput(output string) []git.Worktree {

--- a/cmd/wtp/list_test.go
+++ b/cmd/wtp/list_test.go
@@ -25,6 +25,7 @@ func TestNewListCommand(t *testing.T) {
 	assert.Equal(t, "List all worktrees", cmd.Usage)
 	assert.NotEmpty(t, cmd.Description)
 	assert.NotNil(t, cmd.Action)
+	assert.NotNil(t, cmd.ShellComplete)
 }
 
 // ===== Pure Business Logic Tests =====
@@ -945,4 +946,21 @@ detached
 	assert.NotContains(t, output, "detached HEAD")
 	assert.NotContains(t, output, "BRANCH")
 	assert.NotContains(t, output, "HEAD")
+}
+
+func TestCompleteList_SuggestsQuietFlag(t *testing.T) {
+	t.Run("suggests quiet flag alias", func(t *testing.T) {
+		originalArgs := os.Args
+		t.Cleanup(func() { os.Args = originalArgs })
+
+		os.Args = []string{"wtp", "list", "--q", "--generate-shell-completion"}
+
+		var buf bytes.Buffer
+		cmd := NewListCommand()
+		cmd.Writer = &buf
+
+		cmd.ShellComplete(context.Background(), cmd)
+
+		assert.Contains(t, buf.String(), "--quiet")
+	})
 }


### PR DESCRIPTION
## Summary
- add shell completion hook so `wtp list` suggests the quiet flag
- add tests covering the new completion path

## Testing
- go test ./cmd/wtp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shell completion support to the list command with intelligent flag suggestions during tab completion.

* **Tests**
  * Added test coverage to verify shell completion functionality and flag hint generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->