### PR TITLE
chore: automate version management

### DIFF
--- a/cmd/wtp/main.go
+++ b/cmd/wtp/main.go
@@ -6,11 +6,16 @@ import (
 	"os"
 )
 
-// Version information (set by GoReleaser)
+// Version information
+// - In releases: set by GoReleaser via ldflags
+// - In dev builds: set by Taskfile via ldflags from git describe
+// - Default: used only when built without ldflags (e.g., go run)
+// Note: commit and date are set via ldflags but not currently displayed.
+// They are available for future use (e.g., verbose version info).
 var (
-	version = "2.3.1"
-	_       = "none"    // commit - set by GoReleaser but not used
-	_       = "unknown" // date - set by GoReleaser but not used
+	version = "dev"
+	commit  = "none"    //nolint:unused // Set via ldflags, available for future use
+	date    = "unknown" //nolint:unused // Set via ldflags, available for future use
 )
 
 func main() {


### PR DESCRIPTION
## Summary
Eliminates the need to manually update version numbers in source code by leveraging existing ldflags injection.

## Changes
- Set default version to `"dev"` in `cmd/wtp/main.go`
- Updated comments to clarify version management strategy

## How It Works
- **Release builds**: GoReleaser sets version from git tags via `-X main.version={{.Version}}`
- **Dev builds**: Taskfile sets version from `git describe` via ldflags
- **Direct `go run`**: Falls back to `"dev"`

## Benefits
- No more manual version updates in code
- Version always reflects git state
- Prevents version mismatch bugs

## Testing
```bash
# Without ldflags
go run ./cmd/wtp --version
# Output: wtp version dev

# With Taskfile (uses git describe)
task build && ./wtp --version
# Output: wtp version v2.3.1-dirty
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Development builds now present a generic "dev" version string and include placeholders for commit/date metadata.
  * Documentation updated to explain how version strings are determined for releases vs development builds and that commit/date may be included in future verbose output.
  * No changes to application behavior, runtime logic, or error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->