### PR TITLE
fix: update module path to v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,7 @@ linters-settings:
         list-mode: lax
         allow:
           - $gostd
-          - github.com/satococoa/wtp
+          - github.com/satococoa/wtp/v2
           - github.com/urfave/cli/v3
           - go.yaml.in/yaml/v3
   govet:
@@ -26,7 +26,7 @@ linters-settings:
   lll:
     line-length: 120
   goimports:
-    local-prefixes: github.com/satococoa/wtp
+    local-prefixes: github.com/satococoa/wtp/v2
   gocritic:
     enabled-tags:
       - diagnostic

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 - Consolidates design decisions, workflow expectations, and coding standards previously split across `AGENTS.md` and `CLAUDE.md`.
 
 ## Project Structure & Modules
-- Root module: `github.com/satococoa/wtp` (Go 1.24).
+- Root module: `github.com/satococoa/wtp/v2` (Go 1.24).
 - CLI entrypoint: `cmd/wtp`.
 - Internal packages: `internal/{git,config,hooks,command,errors,io}`.
 - Tests: unit tests alongside packages (`*_test.go`), end-to-end tests in `test/e2e`.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ brew install satococoa/tap/wtp
 ### Using Go
 
 ```bash
-go install github.com/satococoa/wtp/cmd/wtp@latest
+go install github.com/satococoa/wtp/v2/cmd/wtp@latest
 ```
 
 ### Download Binary

--- a/cmd/wtp/add.go
+++ b/cmd/wtp/add.go
@@ -13,12 +13,12 @@ import (
 
 	"github.com/urfave/cli/v3"
 
-	"github.com/satococoa/wtp/internal/command"
-	"github.com/satococoa/wtp/internal/config"
-	"github.com/satococoa/wtp/internal/errors"
-	"github.com/satococoa/wtp/internal/git"
-	"github.com/satococoa/wtp/internal/hooks"
-	wtpio "github.com/satococoa/wtp/internal/io"
+	"github.com/satococoa/wtp/v2/internal/command"
+	"github.com/satococoa/wtp/v2/internal/config"
+	"github.com/satococoa/wtp/v2/internal/errors"
+	"github.com/satococoa/wtp/v2/internal/git"
+	"github.com/satococoa/wtp/v2/internal/hooks"
+	wtpio "github.com/satococoa/wtp/v2/internal/io"
 )
 
 // NewAddCommand creates the add command definition

--- a/cmd/wtp/add_test.go
+++ b/cmd/wtp/add_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli/v3"
 
-	"github.com/satococoa/wtp/internal/command"
-	"github.com/satococoa/wtp/internal/config"
-	"github.com/satococoa/wtp/internal/errors"
+	"github.com/satococoa/wtp/v2/internal/command"
+	"github.com/satococoa/wtp/v2/internal/config"
+	"github.com/satococoa/wtp/v2/internal/errors"
 )
 
 // ===== Command Structure Tests =====

--- a/cmd/wtp/cd.go
+++ b/cmd/wtp/cd.go
@@ -12,10 +12,10 @@ import (
 
 	"github.com/urfave/cli/v3"
 
-	"github.com/satococoa/wtp/internal/command"
-	"github.com/satococoa/wtp/internal/config"
-	"github.com/satococoa/wtp/internal/errors"
-	"github.com/satococoa/wtp/internal/git"
+	"github.com/satococoa/wtp/v2/internal/command"
+	"github.com/satococoa/wtp/v2/internal/config"
+	"github.com/satococoa/wtp/v2/internal/errors"
+	"github.com/satococoa/wtp/v2/internal/git"
 )
 
 // isWorktreeManagedCd determines if a worktree is managed by wtp (for cd command)

--- a/cmd/wtp/init.go
+++ b/cmd/wtp/init.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/urfave/cli/v3"
 
-	"github.com/satococoa/wtp/internal/config"
-	"github.com/satococoa/wtp/internal/errors"
-	"github.com/satococoa/wtp/internal/git"
+	"github.com/satococoa/wtp/v2/internal/config"
+	"github.com/satococoa/wtp/v2/internal/errors"
+	"github.com/satococoa/wtp/v2/internal/git"
 )
 
 const configFileMode = 0o600

--- a/cmd/wtp/init_test.go
+++ b/cmd/wtp/init_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli/v3"
 
-	"github.com/satococoa/wtp/internal/config"
+	"github.com/satococoa/wtp/v2/internal/config"
 )
 
 func TestNewInitCommand(t *testing.T) {

--- a/cmd/wtp/list.go
+++ b/cmd/wtp/list.go
@@ -12,10 +12,10 @@ import (
 	"github.com/urfave/cli/v3"
 	"golang.org/x/term"
 
-	"github.com/satococoa/wtp/internal/command"
-	"github.com/satococoa/wtp/internal/config"
-	"github.com/satococoa/wtp/internal/errors"
-	"github.com/satococoa/wtp/internal/git"
+	"github.com/satococoa/wtp/v2/internal/command"
+	"github.com/satococoa/wtp/v2/internal/config"
+	"github.com/satococoa/wtp/v2/internal/errors"
+	"github.com/satococoa/wtp/v2/internal/git"
 )
 
 // Display constants

--- a/cmd/wtp/list_test.go
+++ b/cmd/wtp/list_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli/v3"
 
-	"github.com/satococoa/wtp/internal/command"
-	"github.com/satococoa/wtp/internal/config"
+	"github.com/satococoa/wtp/v2/internal/command"
+	"github.com/satococoa/wtp/v2/internal/config"
 )
 
 func defaultListDisplayOptionsForTests() listDisplayOptions {

--- a/cmd/wtp/remove.go
+++ b/cmd/wtp/remove.go
@@ -12,10 +12,10 @@ import (
 
 	"github.com/urfave/cli/v3"
 
-	"github.com/satococoa/wtp/internal/command"
-	"github.com/satococoa/wtp/internal/config"
-	"github.com/satococoa/wtp/internal/errors"
-	"github.com/satococoa/wtp/internal/git"
+	"github.com/satococoa/wtp/v2/internal/command"
+	"github.com/satococoa/wtp/v2/internal/config"
+	"github.com/satococoa/wtp/v2/internal/errors"
+	"github.com/satococoa/wtp/v2/internal/git"
 )
 
 // Variable to allow mocking in tests

--- a/cmd/wtp/remove_test.go
+++ b/cmd/wtp/remove_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli/v3"
 
-	"github.com/satococoa/wtp/internal/command"
+	"github.com/satococoa/wtp/v2/internal/command"
 )
 
 // ===== Command Structure Tests =====

--- a/cmd/wtp/testhelpers_test.go
+++ b/cmd/wtp/testhelpers_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/satococoa/wtp/internal/config"
+	"github.com/satococoa/wtp/v2/internal/config"
 )
 
 // RunWriterCommonTests runs a common pair of tests for functions that write

--- a/cmd/wtp/worktree_managed.go
+++ b/cmd/wtp/worktree_managed.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/satococoa/wtp/internal/config"
+	"github.com/satococoa/wtp/v2/internal/config"
 )
 
 // isWorktreeManagedCommon determines whether a worktree path is considered managed by wtp.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/satococoa/wtp
+module github.com/satococoa/wtp/v2
 
 go 1.24.4
 

--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/satococoa/wtp/internal/errors"
+	"github.com/satococoa/wtp/v2/internal/errors"
 )
 
 type Repository struct {

--- a/internal/hooks/executor.go
+++ b/internal/hooks/executor.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/satococoa/wtp/internal/config"
+	"github.com/satococoa/wtp/v2/internal/config"
 )
 
 const (

--- a/internal/hooks/executor_test.go
+++ b/internal/hooks/executor_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/satococoa/wtp/internal/config"
+	"github.com/satococoa/wtp/v2/internal/config"
 )
 
 func TestExecutePostCreateHooks_NilConfig(t *testing.T) {

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/satococoa/wtp/test/e2e/framework"
+	"github.com/satococoa/wtp/v2/test/e2e/framework"
 )
 
 func TestBasicCommands(t *testing.T) {

--- a/test/e2e/error_test.go
+++ b/test/e2e/error_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/satococoa/wtp/test/e2e/framework"
+	"github.com/satococoa/wtp/v2/test/e2e/framework"
 )
 
 func TestErrorMessages(t *testing.T) {

--- a/test/e2e/hook_streaming_test.go
+++ b/test/e2e/hook_streaming_test.go
@@ -7,7 +7,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/satococoa/wtp/test/e2e/framework"
+	"github.com/satococoa/wtp/v2/test/e2e/framework"
 )
 
 func TestHookOutputStreaming(t *testing.T) {

--- a/test/e2e/integration_test.go
+++ b/test/e2e/integration_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/satococoa/wtp/test/e2e/framework"
+	"github.com/satococoa/wtp/v2/test/e2e/framework"
 )
 
 // TestConfigBaseDirIntegration tests that base_dir configuration is properly handled

--- a/test/e2e/remote_test.go
+++ b/test/e2e/remote_test.go
@@ -3,7 +3,7 @@ package e2e
 import (
 	"testing"
 
-	"github.com/satococoa/wtp/test/e2e/framework"
+	"github.com/satococoa/wtp/v2/test/e2e/framework"
 )
 
 func TestRemoteBranchHandling(t *testing.T) {

--- a/test/e2e/shell_test.go
+++ b/test/e2e/shell_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/satococoa/wtp/test/e2e/framework"
+	"github.com/satococoa/wtp/v2/test/e2e/framework"
 )
 
 func TestShellIntegration(t *testing.T) {

--- a/test/e2e/worktree_creation_test.go
+++ b/test/e2e/worktree_creation_test.go
@@ -3,7 +3,7 @@ package e2e
 import (
 	"testing"
 
-	"github.com/satococoa/wtp/test/e2e/framework"
+	"github.com/satococoa/wtp/v2/test/e2e/framework"
 )
 
 // Living Specifications for Worktree Creation Workflows

--- a/test/e2e/worktree_test.go
+++ b/test/e2e/worktree_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/satococoa/wtp/test/e2e/framework"
+	"github.com/satococoa/wtp/v2/test/e2e/framework"
 )
 
 func TestWorktreeCreation(t *testing.T) {


### PR DESCRIPTION
## Summary
- switch go module path to github.com/satococoa/wtp/v2
- update imports, lint config, and docs for v2 usage

## Testing
- go tool task dev

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated module path versioning to v2 across configuration and import paths.

* **Documentation**
  * Updated installation instructions to reflect v2 module path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->