### PR TITLE
fix: show module version for go install builds

### DIFF
--- a/cmd/wtp/main.go
+++ b/cmd/wtp/main.go
@@ -12,13 +12,17 @@ import (
 // - Default: used only when built without ldflags (e.g., go run)
 // Note: commit and date are set via ldflags but not currently displayed.
 // They are available for future use (e.g., verbose version info).
+const defaultVersion = "dev"
+
 var (
-	version = "dev"
+	version = defaultVersion
 	commit  = "none"    //nolint:unused // Set via ldflags, available for future use
 	date    = "unknown" //nolint:unused // Set via ldflags, available for future use
 )
 
 func main() {
+	initVersion()
+
 	app := newApp()
 
 	args := normalizeCompletionArgs(os.Args)

--- a/cmd/wtp/main_test.go
+++ b/cmd/wtp/main_test.go
@@ -47,8 +47,8 @@ func TestMain(t *testing.T) {
 func TestVersionInfo(t *testing.T) {
 	// Test version is set
 	assert.NotEmpty(t, version)
-	// In tests, version is usually "dev"
-	if version != "dev" {
+	// In tests, version is usually the default
+	if version != defaultVersion {
 		// If not dev, should be a valid version format
 		assert.Regexp(t, `^\d+\.\d+\.\d+`, version)
 	}

--- a/cmd/wtp/version_info.go
+++ b/cmd/wtp/version_info.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"runtime/debug"
+)
+
+var readBuildInfo = debug.ReadBuildInfo
+
+func initVersion() {
+	if version != defaultVersion {
+		return
+	}
+
+	info, ok := readBuildInfo()
+	if !ok || info == nil {
+		return
+	}
+
+	if info.Main.Version == "" || info.Main.Version == "(devel)" {
+		return
+	}
+
+	version = info.Main.Version
+}

--- a/cmd/wtp/version_info_test.go
+++ b/cmd/wtp/version_info_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"runtime/debug"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitVersionUsesBuildInfoWhenDev(t *testing.T) {
+	prevVersion := version
+	prevReader := readBuildInfo
+	t.Cleanup(func() {
+		version = prevVersion
+		readBuildInfo = prevReader
+	})
+
+	version = defaultVersion
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Main: debug.Module{
+				Path:    "github.com/satococoa/wtp/v2",
+				Version: "v2.3.4",
+			},
+		}, true
+	}
+
+	initVersion()
+
+	assert.Equal(t, "v2.3.4", version)
+}
+
+func TestInitVersionIgnoresDevelVersion(t *testing.T) {
+	prevVersion := version
+	prevReader := readBuildInfo
+	t.Cleanup(func() {
+		version = prevVersion
+		readBuildInfo = prevReader
+	})
+
+	version = defaultVersion
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Main: debug.Module{
+				Path:    "github.com/satococoa/wtp/v2",
+				Version: "(devel)",
+			},
+		}, true
+	}
+
+	initVersion()
+
+	assert.Equal(t, defaultVersion, version)
+}
+
+func TestInitVersionRespectsPresetVersion(t *testing.T) {
+	prevVersion := version
+	prevReader := readBuildInfo
+	t.Cleanup(func() {
+		version = prevVersion
+		readBuildInfo = prevReader
+	})
+
+	version = "custom"
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Main: debug.Module{
+				Path:    "github.com/satococoa/wtp/v2",
+				Version: "v2.3.4",
+			},
+		}, true
+	}
+
+	initVersion()
+
+	assert.Equal(t, "custom", version)
+}


### PR DESCRIPTION
## Summary
- add runtime detection of module version via build info when ldflags not provided
- ensure go install binaries report release version instead of dev
- add tests covering build info fallback logic

## Testing
- go tool task dev

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application now automatically embeds and displays actual build version information when available, instead of always showing "dev".

* **Tests**
  * Added comprehensive tests to validate version initialization behavior during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->