### PR TITLE
feat: display cd guidance after hooks execution

### DIFF
--- a/cmd/wtp/add.go
+++ b/cmd/wtp/add.go
@@ -106,14 +106,11 @@ func addCommandWithCommandExecutor(
 		return analyzeGitWorktreeError(workTreePath, branchName, gitError, gitOutput)
 	}
 
-	// Display success message
-	displaySuccessMessage(w, branchName, workTreePath, cfg, mainRepoPath)
-
-	// Execute post-create hooks
 	if err := executePostCreateHooks(w, cfg, mainRepoPath, workTreePath); err != nil {
-		// Log warning but don't fail the entire operation
 		fmt.Fprintf(w, "Warning: Hook execution failed: %v\n", err)
 	}
+
+	displaySuccessMessage(w, branchName, workTreePath, cfg, mainRepoPath)
 
 	return nil
 }


### PR DESCRIPTION
## Summary
- Display the `wtp cd` guidance message after executing post-create hooks instead of before
- Improves UX when hooks take time to execute

## Changes
- Reordered output in `addCommandWithCommandExecutor` to show hooks execution first, then success message

## Benefits
- Users can immediately see which worktree to navigate to without scrolling up
- The most relevant information appears at the most relevant time (right when you're ready to use it)

## Testing
- All existing tests pass
- No behavioral changes to hook execution or worktree creation

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved operation sequencing by displaying the success confirmation after background operations complete, rather than before, ensuring proper order of execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->