### PR TITLE
fix(fish-completions): don't execute with `env`

### DIFF
--- a/cmd/wtp/completion_config.go
+++ b/cmd/wtp/completion_config.go
@@ -117,7 +117,7 @@ function __fish_wtp_dynamic_complete --description 'wtp dynamic completion helpe
 		return
 	end
 
-	set -l raw (env WTP_SHELL_COMPLETION=1 command wtp $args)
+	set -l raw (WTP_SHELL_COMPLETION=1 command wtp $args)
 	for line in $raw
 		if test -z "$line"
 			continue

--- a/cmd/wtp/testdata/completion/fish_expected.fish
+++ b/cmd/wtp/testdata/completion/fish_expected.fish
@@ -22,7 +22,7 @@ function __fish_wtp_dynamic_complete --description 'wtp dynamic completion helpe
 		return
 	end
 
-	set -l raw (env WTP_SHELL_COMPLETION=1 command wtp $args)
+	set -l raw (WTP_SHELL_COMPLETION=1 command wtp $args)
 	for line in $raw
 		if test -z "$line"
 			continue


### PR DESCRIPTION
Using `env` broke Fish completions because `command` is a Fish builtin while `env` is an external program unaware of what Fish does and doesn't provide:

    env: ‘command’: No such file or directory

Fish supports `FIELD=val` natively, so we can just remove `env`.

Assisted-by: Claude Sonnet 4.5 via Crush <crush@charm.land>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved shell completion efficiency by optimizing how environment variables are passed to the completion command.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->