### PR TITLE
feat(config): add global config file support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,8 @@
 ## Security & Configuration Tips
 - Project hooks are defined in `.wtp.yml`. Keep commands deterministic and safe; avoid destructive steps by default.
 - Do not commit secrets; use example files (e.g., `.env.example`) and copy in hooks.
+- Global config is loaded from `$XDG_CONFIG_HOME/wtp/config.yml` (or `~/.config/wtp/config.yml` fallback).
+- Global settings are merged with project-local `.wtp.yml`; project settings override global for `base_dir`, hooks concatenate (global first, then project).
 
 ## TDD Workflow
 ### Development Cycle Expectations

--- a/README.md
+++ b/README.md
@@ -246,6 +246,37 @@ hooks:
 This behavior applies regardless of where you run `wtp add` from (main worktree
 or any other worktree).
 
+### Global Configuration
+
+For settings you want across all repositories, create a global config at
+`$XDG_CONFIG_HOME/wtp/config.yml` (defaults to `~/.config/wtp/config.yml`):
+
+```yaml
+version: "1.0"
+defaults:
+  # git clone https://pro.je/c/t.git project/main, create all worktrees/branches as siblings:
+  # - repos/project/main
+  # - repos/project/feature
+  # instead of
+  # - repos/project/ 
+  # - repos/worktrees/feature or
+  # - repos/project/.git/wtp/worktrees/feature
+  base_dir: ".."
+
+hooks:
+  post_create:
+    # Common hooks that run for all repositories
+    - type: copy
+      from: "AGENTS.md"
+      to: "AGENTS.md"
+```
+
+**Merge behavior:**
+
+- `base_dir`: project `.wtp.yml` overrides global if set
+- `hooks`: concatenate (global hooks run first, then project hooks)
+- `version`: project takes precedence
+
 ## Shell Integration
 
 ### Tab Completion Setup

--- a/cmd/wtp/main_test.go
+++ b/cmd/wtp/main_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-func TestMain(t *testing.T) {
+func TestAppSetup(t *testing.T) {
 	// Test main function doesn't crash
 	// This is tricky to test directly, so we test the app setup instead
 	t.Run("app setup", func(t *testing.T) {

--- a/cmd/wtp/testhelpers_test.go
+++ b/cmd/wtp/testhelpers_test.go
@@ -12,6 +12,31 @@ import (
 	"github.com/satococoa/wtp/v2/internal/config"
 )
 
+// TestMain sets up the test environment for all tests in the package.
+// It isolates tests from the user's real global config by setting XDG_CONFIG_HOME
+// to a temporary directory.
+func TestMain(m *testing.M) {
+	// Create a temp directory for XDG_CONFIG_HOME to isolate tests
+	// from the user's real global config
+	tmpDir, err := os.MkdirTemp("", "wtp-test-config-*")
+	if err != nil {
+		os.Exit(1)
+	}
+
+	if err := os.Setenv("XDG_CONFIG_HOME", tmpDir); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+
+	// Cleanup
+	_ = os.Unsetenv("XDG_CONFIG_HOME")
+	_ = os.RemoveAll(tmpDir)
+
+	os.Exit(code)
+}
+
 // RunWriterCommonTests runs a common pair of tests for functions that write
 // to an io.Writer and may interact with a Git repo. It validates that the
 // function does not panic in non-repo contexts and when a bare .git dir exists.

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -231,7 +231,13 @@ func (r *TestRepo) RunWTP(args ...string) (string, error) {
 	// Create command with validated binary path
 	cmd := createSafeCommand(r.env.wtpBinary, args...)
 	cmd.Dir = r.path
-	cmd.Env = append(os.Environ(), "HOME="+r.env.tmpDir)
+	// Use a subdirectory for XDG_CONFIG_HOME to avoid conflicts with the wtp binary
+	// which is placed at $tmpDir/wtp
+	xdgConfigDir := filepath.Join(r.env.tmpDir, "xdg-config")
+	cmd.Env = append(os.Environ(),
+		"HOME="+r.env.tmpDir,
+		"XDG_CONFIG_HOME="+xdgConfigDir,
+	)
 
 	output, err := cmd.CombinedOutput()
 	return string(output), err


### PR DESCRIPTION
I've got some workflows that rely on the same local files/dirs across multiple (even all) projects. I also really like using a common worktree structure across all the projects I create/contribute to, described in that `base_dir: ".."` example workflow I left in the `### Global Configuration` comments (happy to remove before merge).

Copying mostly-the-same config files around to all the projects then making tiny additions would be quite tedious, so this loads a global config from `$XDG_CONFIG_HOME/wtp/config.yml` (or `~/.config/wtp/config.yml` fallback) and merges with the project-local `.wtp.yml`.

- defaults: project wins if set, otherwise global
- hooks: concatenate (global first, then project)
- version: project wins

Happy to modify any of this before merge, or even keep it in a soft fork if you'd prefer not to maintain the changes. Thank you for creating `wtp` :slightly_smiling_face: 

Assisted-by: Claude Opus 4.5 via Crush
Assisted-by: Claude Sonnet 4.5 via Crush

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global configuration support: reads $XDG_CONFIG_HOME/wtp/config.yml (fallback ~/.config/wtp/config.yml) and merges with project config; project values override base_dir and hooks are concatenated with global hooks first.

* **Documentation**
  * README added Global Configuration section describing file location and merge/precedence behavior.

* **Tests**
  * Tests expanded for global config loading, merging, validation; test harness isolates XDG_CONFIG_HOME/HOME for reliable test runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->