### PR TITLE
test: centralize git test repo config

### DIFF
--- a/internal/git/repository_remove_test.go
+++ b/internal/git/repository_remove_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/satococoa/wtp/v2/internal/testutil"
 )
 
 // runGitCommand is a helper to run git commands in tests
@@ -32,9 +34,9 @@ func checkoutMainBranch(t *testing.T, repoDir string) {
 func initializeTestRepo(t *testing.T, repoDir string) {
 	t.Helper()
 	runGitCommand(t, repoDir, "init")
-	runGitCommand(t, repoDir, "config", "user.name", "Test User")
-	runGitCommand(t, repoDir, "config", "user.email", "test@example.com")
-	runGitCommand(t, repoDir, "config", "commit.gpgsign", "false")
+	testutil.ConfigureTestRepo(t, repoDir, func(dir string, args ...string) {
+		runGitCommand(t, dir, args...)
+	})
 
 	// Create initial commit
 	readmeFile := filepath.Join(repoDir, "README.md")

--- a/internal/git/repository_test.go
+++ b/internal/git/repository_test.go
@@ -6,10 +6,22 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/satococoa/wtp/v2/internal/testutil"
 )
 
 func setupTestRepo(t *testing.T) string {
 	tempDir := t.TempDir()
+
+	runGitCommand := func(dir string, args ...string) {
+		t.Helper()
+
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("Failed to run git %v: %v", args, err)
+		}
+	}
 
 	// Initialize git repository
 	cmd := exec.Command("git", "init")
@@ -23,24 +35,7 @@ func setupTestRepo(t *testing.T) string {
 	cmd.Dir = tempDir
 	_ = cmd.Run() // Ignore error if git version is too old
 
-	// Configure git user
-	cmd = exec.Command("git", "config", "user.name", "Test User")
-	cmd.Dir = tempDir
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("Failed to configure git user: %v", err)
-	}
-
-	cmd = exec.Command("git", "config", "user.email", "test@example.com")
-	cmd.Dir = tempDir
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("Failed to configure git email: %v", err)
-	}
-
-	cmd = exec.Command("git", "config", "commit.gpgsign", "false")
-	cmd.Dir = tempDir
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("Failed to disable gpgsign: %v", err)
-	}
+	testutil.ConfigureTestRepo(t, tempDir, runGitCommand)
 
 	// Create initial commit
 	readmeFile := filepath.Join(tempDir, "README.md")

--- a/internal/testutil/git.go
+++ b/internal/testutil/git.go
@@ -1,0 +1,25 @@
+// Package testutil provides helpers shared across tests.
+// Package testutil provides helpers shared across tests.
+// Package testutil provides helpers shared across tests.
+// Package testutil provides helpers shared across tests.
+package testutil
+
+import "testing"
+
+// ConfigureTestRepo applies common git configuration used in tests.
+//
+// The runner is responsible for executing git commands within the provided
+// repository directory and should handle errors appropriately.
+func ConfigureTestRepo(t *testing.T, repoDir string, runner func(dir string, args ...string)) {
+	t.Helper()
+
+	commands := [][]string{
+		{"config", "user.name", "Test User"},
+		{"config", "user.email", "test@example.com"},
+		{"config", "commit.gpgsign", "false"},
+	}
+
+	for _, args := range commands {
+		runner(repoDir, args...)
+	}
+}

--- a/internal/testutil/git_test.go
+++ b/internal/testutil/git_test.go
@@ -1,0 +1,30 @@
+package testutil
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestConfigureTestRepo(t *testing.T) {
+	repoDir := t.TempDir()
+
+	var calls [][]string
+	runner := func(dir string, args ...string) {
+		if dir != repoDir {
+			t.Fatalf("runner dir = %s, want %s", dir, repoDir)
+		}
+		calls = append(calls, args)
+	}
+
+	ConfigureTestRepo(t, repoDir, runner)
+
+	want := [][]string{
+		{"config", "user.name", "Test User"},
+		{"config", "user.email", "test@example.com"},
+		{"config", "commit.gpgsign", "false"},
+	}
+
+	if !reflect.DeepEqual(calls, want) {
+		t.Fatalf("runner calls = %#v, want %#v", calls, want)
+	}
+}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/satococoa/wtp/v2/internal/testutil"
 )
 
 const (
@@ -97,9 +99,9 @@ func (e *TestEnvironment) CreateTestRepo(name string) *TestRepo {
 	repoDir := filepath.Join(e.tmpDir, name)
 
 	e.run("git", "init", repoDir)
-	e.runInDir(repoDir, "git", "config", "user.name", "Test User")
-	e.runInDir(repoDir, "git", "config", "user.email", "test@example.com")
-	e.runInDir(repoDir, "git", "config", "commit.gpgsign", "false")
+	testutil.ConfigureTestRepo(e.t, repoDir, func(dir string, args ...string) {
+		e.runInDir(dir, "git", args...)
+	})
 
 	// Ensure the default branch is 'main' regardless of global git config
 	e.runInDir(repoDir, "git", "config", "init.defaultBranch", "main")


### PR DESCRIPTION
Resolves https://github.com/satococoa/wtp/issues/60

## Summary
- add shared helper ConfigureTestRepo under internal/testutil
- replace duplicated git user config setup in unit/e2e tests
- add unit test for helper

## Testing
- GOCACHE=/tmp/wtp-clone-MFCs9r/.cache/go-build go tool task test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a unit test validating centralized test-repo configuration to ensure consistent git settings during tests.
  * Updated test suites and end-to-end test setup to use the centralized configuration helper for repository setup.

* **Chores**
  * Consolidated repository initialization logic across test infrastructure to improve maintainability and reduce duplication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->