### PR TITLE
feat(cd): default to main worktree sans args

### DIFF
--- a/cmd/wtp/cd.go
+++ b/cmd/wtp/cd.go
@@ -28,15 +28,17 @@ func NewCdCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "cd",
 		Usage: "Output absolute path to worktree",
-		Description: "Output the absolute path to the specified worktree.\n\n" +
+		Description: "Output the absolute path to the specified worktree.\n" +
+			"If no worktree is specified, outputs the main worktree path (like cd goes to $HOME).\n\n" +
 			"Usage:\n" +
 			"  Direct:     cd \"$(wtp cd feature)\"\n" +
-			"  With hook:  wtp cd feature\n\n" +
+			"  With hook:  wtp cd feature\n" +
+			"  Go home:    wtp cd\n\n" +
 			"To enable the hook for easier navigation:\n" +
 			"  Bash: eval \"$(wtp hook bash)\"\n" +
 			"  Zsh:  eval \"$(wtp hook zsh)\"\n" +
 			"  Fish: wtp hook fish | source",
-		ArgsUsage:     "<worktree-name>",
+		ArgsUsage:     "[worktree-name]",
 		Action:        cdToWorktree,
 		ShellComplete: completeWorktreesForCd,
 	}
@@ -44,11 +46,12 @@ func NewCdCommand() *cli.Command {
 
 func cdToWorktree(_ context.Context, cmd *cli.Command) error {
 	args := cmd.Args()
-	if args.Len() == 0 {
-		return errors.WorktreeNameRequired()
-	}
 
-	worktreeName := args.Get(0)
+	// Default to main worktree (@) when no argument provided, like cd goes to $HOME
+	worktreeName := "@"
+	if args.Len() > 0 {
+		worktreeName = args.Get(0)
+	}
 
 	// Get current directory
 	cwd, err := os.Getwd()

--- a/cmd/wtp/cd_test.go
+++ b/cmd/wtp/cd_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -119,42 +118,6 @@ func TestCdCommand_NoEnvironmentVariableDependency(t *testing.T) {
 			resolvedPath := resolveCdWorktreePath("@", worktrees, mainPath)
 			assert.Equal(t, "/test/main", resolvedPath,
 				"Path resolution must not depend on environment variables")
-		})
-	}
-}
-
-// Test critical error scenarios that users will encounter
-func TestCdCommand_UserFacingErrors(t *testing.T) {
-	tests := []struct {
-		name          string
-		args          []string
-		expectedError string
-	}{
-		{
-			name:          "no arguments",
-			args:          []string{},
-			expectedError: "worktree name is required",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			app := &cli.Command{
-				Commands: []*cli.Command{
-					NewCdCommand(),
-				},
-			}
-
-			var buf bytes.Buffer
-			app.Writer = &buf
-
-			ctx := context.Background()
-			cmdArgs := []string{"wtp", "cd"}
-			cmdArgs = append(cmdArgs, tt.args...)
-
-			err := app.Run(ctx, cmdArgs)
-			assert.Error(t, err)
-			assert.Contains(t, err.Error(), tt.expectedError)
 		})
 	}
 }


### PR DESCRIPTION
Like `cd` defaults to `$HOME` without args, I thought it would be nice if `wtp cd` took the user to the main worktree, `@`, when invoked without args instead of emitting an error.

Assisted-by: Claude Opus 4.5 via Crush

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The `cd` command now defaults to the main worktree when no worktree is specified; usage and examples updated to show the worktree argument as optional.

* **Tests**
  * Removed a test that validated user-facing error output via the CLI; core behavior and other tests remain.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->