### PR TITLE
fix(hook): declare fish target_dir variable outside if/else block to fix scoping

### DIFF
--- a/cmd/wtp/hook.go
+++ b/cmd/wtp/hook.go
@@ -143,10 +143,11 @@ function wtp
         end
     end
     if test "$argv[1]" = "cd"
+        set -l target_dir
         if test -z "$argv[2]"
-            set -l target_dir (command wtp cd 2>/dev/null)
+            set target_dir (command wtp cd 2>/dev/null)
         else
-            set -l target_dir (command wtp cd $argv[2] 2>/dev/null)
+            set target_dir (command wtp cd $argv[2] 2>/dev/null)
         end
         if test $status -eq 0 -a -n "$target_dir"
             cd "$target_dir"


### PR DESCRIPTION
## What

Fix fish shell variable scoping bug in `wtp cd` hook that caused the command to fail silently.

## Why

The `wtp cd <worktree>` command was not working in fish shell. The `target_dir` variable was always empty when checked outside the if/else block, causing the hook to fall through to the error handling path instead of changing directories.

This bug was introduced in commit 3afdc10 (#64) when adding support for no-argument `wtp cd`. The fish implementation incorrectly declared `target_dir` with `set -l` inside the if/else blocks, but fish's block scoping means local variables declared inside a block are not accessible outside it.

## How

Declare the local variable before the if/else block, then assign to it (without `-l`) inside the blocks:

  ```fish
  # Before (broken)
  if test -z "$argv[2]"
      set -l target_dir (command wtp cd 2>/dev/null)
  else
      set -l target_dir (command wtp cd $argv[2] 2>/dev/null)
  end
  # $target_dir is empty here!

  # After (fixed)
  set -l target_dir
  if test -z "$argv[2]"
      set target_dir (command wtp cd 2>/dev/null)
  else
      set target_dir (command wtp cd $argv[2] 2>/dev/null)
  end
  # $target_dir contains the path
```

##  Testing

  - Added TestFishHook_VariableScoping to verify correct variable declaration pattern
  - Updated existing fish hook tests to expect the fixed syntax
  - All unit tests pass
  - Manual verification:
  source (wtp shell-init fish | psub)
  wtp cd <existing-worktree>  # now works correctly

##  Breaking Changes

None. This is a bug fix that makes the existing wtp cd command work as documented in fish shell.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Fish shell variable scoping for the cd command to ensure correct behavior.

* **Tests**
  * Added test coverage for variable scoping validation in shell hooks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->