### PR TITLE
Fix completion logic bug when flags are present

### DIFF
--- a/cmd/wtp/flag_completion.go
+++ b/cmd/wtp/flag_completion.go
@@ -130,8 +130,19 @@ func maybeCompleteFlagSuggestions(cmd *cli.Command, current string, previous []s
 	}
 
 	if candidate, ok := flagCandidateFromOSArgs(); ok {
-		if candidate != "" && candidate != currentNormalized && tryFlagCompletion(cmd, candidate) {
-			return true
+		if candidate != "" && candidate != currentNormalized {
+			// When the shell drops the current word (because it does not
+			// start with "-"), cmd.Args() is empty and the OS-args candidate
+			// is the previous argument. If that argument is a fully-typed
+			// flag, the shell is completing the flag's value or the next
+			// positional — not the flag name — so skip flag completion and
+			// let the command's own completion handler run.
+			if currentNormalized == "" && isCompleteFlagName(cmd, candidate) {
+				return false
+			}
+			if tryFlagCompletion(cmd, candidate) {
+				return true
+			}
 		}
 	}
 
@@ -158,4 +169,41 @@ func flagCandidateFromOSArgs() (string, bool) {
 	}
 
 	return candidate, candidate != ""
+}
+
+// isCompleteFlagName reports whether candidate is an exact match for a flag
+// name or alias defined on cmd or any of its ancestors. Dash conventions are
+// respected: a double-dash candidate ("--name") only matches multi-character
+// flag names (not single-character aliases), while a single-dash candidate
+// ("-x") matches both single-character aliases and full names.
+func isCompleteFlagName(cmd *cli.Command, candidate string) bool {
+	if !strings.HasPrefix(candidate, "-") || candidate == "-" || candidate == "--" {
+		return false
+	}
+
+	doubleDash := strings.HasPrefix(candidate, "--")
+	name := strings.TrimLeft(candidate, "-")
+
+	if idx := strings.Index(name, "="); idx != -1 {
+		name = name[:idx]
+	}
+
+	if name == "" {
+		return false
+	}
+
+	for _, pCmd := range cmd.Lineage() {
+		for _, flag := range pCmd.Flags {
+			for _, n := range flag.Names() {
+				if doubleDash && utf8.RuneCountInString(n) == 1 {
+					continue
+				}
+				if n == name {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
 }

--- a/cmd/wtp/flag_completion_test.go
+++ b/cmd/wtp/flag_completion_test.go
@@ -121,3 +121,188 @@ func TestMaybeCompleteFlagSuggestions_UsesOSArgsWhenCurrentEmpty(t *testing.T) {
 	require.True(t, maybeCompleteFlagSuggestions(cmd, "", nil))
 	require.Contains(t, buf.String(), "--with-branch")
 }
+
+func TestIsCompleteFlagName_ShortAlias(t *testing.T) {
+	cmd := &cli.Command{
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "branch", Aliases: []string{"b"}},
+			&cli.BoolFlag{Name: "quiet", Aliases: []string{"q"}},
+			&cli.StringFlag{Name: "exec"},
+		},
+	}
+
+	require.True(t, isCompleteFlagName(cmd, "-b"))
+	require.True(t, isCompleteFlagName(cmd, "-q"))
+}
+
+func TestIsCompleteFlagName_LongName(t *testing.T) {
+	cmd := &cli.Command{
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "branch", Aliases: []string{"b"}},
+			&cli.BoolFlag{Name: "quiet", Aliases: []string{"q"}},
+			&cli.StringFlag{Name: "exec"},
+		},
+	}
+
+	require.True(t, isCompleteFlagName(cmd, "--branch"))
+	require.True(t, isCompleteFlagName(cmd, "--quiet"))
+	require.True(t, isCompleteFlagName(cmd, "--exec"))
+}
+
+func TestIsCompleteFlagName_DoubleDashSkipsSingleCharAlias(t *testing.T) {
+	cmd := &cli.Command{
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "branch", Aliases: []string{"b"}},
+			&cli.BoolFlag{Name: "quiet", Aliases: []string{"q"}},
+		},
+	}
+
+	require.False(t, isCompleteFlagName(cmd, "--b"))
+	require.False(t, isCompleteFlagName(cmd, "--q"))
+}
+
+func TestIsCompleteFlagName_PartialName(t *testing.T) {
+	cmd := &cli.Command{
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "branch", Aliases: []string{"b"}},
+			&cli.BoolFlag{Name: "force", Aliases: []string{"f"}},
+		},
+	}
+
+	require.False(t, isCompleteFlagName(cmd, "--br"))
+	require.False(t, isCompleteFlagName(cmd, "--fo"))
+	require.False(t, isCompleteFlagName(cmd, "-fo"))
+}
+
+func TestIsCompleteFlagName_NonFlagOrEdgeCases(t *testing.T) {
+	cmd := &cli.Command{
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "branch", Aliases: []string{"b"}},
+		},
+	}
+
+	require.False(t, isCompleteFlagName(cmd, "foo"))
+	require.False(t, isCompleteFlagName(cmd, "-"))
+	require.False(t, isCompleteFlagName(cmd, "--"))
+	require.False(t, isCompleteFlagName(cmd, ""))
+	require.False(t, isCompleteFlagName(cmd, "--unknown"))
+}
+
+func TestIsCompleteFlagName_EqualsFormat(t *testing.T) {
+	cmd := &cli.Command{
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "branch", Aliases: []string{"b"}},
+		},
+	}
+
+	require.True(t, isCompleteFlagName(cmd, "--branch=value"))
+	require.True(t, isCompleteFlagName(cmd, "-b=value"))
+}
+
+func TestIsCompleteFlagName_SingleDashFullName(t *testing.T) {
+	cmd := &cli.Command{
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "branch", Aliases: []string{"b"}},
+		},
+	}
+
+	require.True(t, isCompleteFlagName(cmd, "-branch"))
+}
+
+func TestMaybeCompleteFlagSuggestions_SkipsCompleteShortFlag(t *testing.T) {
+	original := os.Args
+	t.Cleanup(func() { os.Args = original })
+
+	os.Args = []string{"wtp", "add", "-b", "--generate-shell-completion"}
+
+	var buf bytes.Buffer
+	cmd := &cli.Command{
+		Writer: &buf,
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "branch", Aliases: []string{"b"}},
+			&cli.BoolFlag{Name: "quiet", Aliases: []string{"q"}},
+			&cli.StringFlag{Name: "exec"},
+			cli.GenerateShellCompletionFlag,
+		},
+	}
+
+	require.False(t, maybeCompleteFlagSuggestions(cmd, "", nil))
+	require.Empty(t, buf.String())
+}
+
+func TestMaybeCompleteFlagSuggestions_SkipsCompleteLongFlag(t *testing.T) {
+	original := os.Args
+	t.Cleanup(func() { os.Args = original })
+
+	os.Args = []string{"wtp", "add", "--branch", "--generate-shell-completion"}
+
+	var buf bytes.Buffer
+	cmd := &cli.Command{
+		Writer: &buf,
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "branch", Aliases: []string{"b"}},
+			cli.GenerateShellCompletionFlag,
+		},
+	}
+
+	require.False(t, maybeCompleteFlagSuggestions(cmd, "", nil))
+	require.Empty(t, buf.String())
+}
+
+func TestMaybeCompleteFlagSuggestions_SkipsCompleteBoolFlag(t *testing.T) {
+	original := os.Args
+	t.Cleanup(func() { os.Args = original })
+
+	os.Args = []string{"wtp", "add", "-q", "--generate-shell-completion"}
+
+	var buf bytes.Buffer
+	cmd := &cli.Command{
+		Writer: &buf,
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "branch", Aliases: []string{"b"}},
+			&cli.BoolFlag{Name: "quiet", Aliases: []string{"q"}},
+			cli.GenerateShellCompletionFlag,
+		},
+	}
+
+	require.False(t, maybeCompleteFlagSuggestions(cmd, "", nil))
+	require.Empty(t, buf.String())
+}
+
+func TestMaybeCompleteFlagSuggestions_PartialFlagStillCompletes(t *testing.T) {
+	original := os.Args
+	t.Cleanup(func() { os.Args = original })
+
+	os.Args = []string{"wtp", "add", "--b", "--generate-shell-completion"}
+
+	var buf bytes.Buffer
+	cmd := &cli.Command{
+		Writer: &buf,
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "branch", Aliases: []string{"b"}},
+			cli.GenerateShellCompletionFlag,
+		},
+	}
+
+	require.True(t, maybeCompleteFlagSuggestions(cmd, "", nil))
+	require.Contains(t, buf.String(), "--branch")
+}
+
+func TestMaybeCompleteFlagSuggestions_CompleteFlagWithCurrentNotEmpty(t *testing.T) {
+	original := os.Args
+	t.Cleanup(func() { os.Args = original })
+
+	os.Args = []string{"wtp", "add", "foo", "-b", "--generate-shell-completion"}
+
+	var buf bytes.Buffer
+	cmd := &cli.Command{
+		Writer: &buf,
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "branch", Aliases: []string{"b"}},
+			cli.GenerateShellCompletionFlag,
+		},
+	}
+
+	require.True(t, maybeCompleteFlagSuggestions(cmd, "foo", nil))
+	require.Contains(t, buf.String(), "--branch")
+}


### PR DESCRIPTION
Heya, another one! If you can tell, I use wtp all the time :)

I've got some worktrees with git submodules in them, so I've got to delete them with -f/--force when cleaning up after I'm done. This caused an issue with the autocompletion, wherein completion for `wtp remove -f feat/` would rewrite to `wtp remove -f --generate-shell-completion` which, in turn, Looks at the last token in the command line, sees a flag in `-f` and enables flag completion. Since "feat/" here is a worktree prefix, it returns flag completions (in this case, nothing).

The fix was to have --generate-shell-completion determine whether or not any preceding flags are fully specified. When they are, it completes worktrees. When they are not, it completes flags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flag completion so fully typed flags and aliases no longer trigger duplicate completion suggestions.
  * Completion now better handles long and short flags, including forms with values like `--name=value`.
  * Partial flags still continue to complete as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->